### PR TITLE
change func name

### DIFF
--- a/contracts/interface/IMarketFactory.sol
+++ b/contracts/interface/IMarketFactory.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.0;
 interface IMarketFactory {
 	event Create(address indexed _market, address _from);
 
-	function enableMarketList() external view returns (address[] memory);
+	function getEnabledMarkets() external view returns (address[] memory);
 
 	function marketsCount() external returns (uint256);
 

--- a/contracts/src/market/MarketFactory.sol
+++ b/contracts/src/market/MarketFactory.sol
@@ -73,7 +73,7 @@ contract MarketFactory is
 		_enable(_addr);
 	}
 
-	function enableMarketList() external view returns (address[] memory) {
+	function getEnabledMarkets() external view returns (address[] memory) {
 		return enabledMarkets;
 	}
 

--- a/test/market/market-factory.ts
+++ b/test/market/market-factory.ts
@@ -140,10 +140,10 @@ contract('MarketFactoryTest', ([deployer, user, dummyMarketAddress]) => {
 		})
 	})
 
-	describe('MarketFactory; enableMarketList', () => {
+	describe('MarketFactory; getEnabledMarkets', () => {
 		it('get market address list', async () => {
 			const [dev, marketAddress] = await init()
-			const result = await dev.marketFactory.enableMarketList()
+			const result = await dev.marketFactory.getEnabledMarkets()
 			expect(result.length).to.be.equal(1)
 			expect(result[0]).to.be.equal(marketAddress)
 		})
@@ -155,7 +155,7 @@ contract('MarketFactoryTest', ([deployer, user, dummyMarketAddress]) => {
 			})
 			const marketAddress2 = getMarketAddress(result)
 			await dev.marketFactory.enable(marketAddress2)
-			const markets = await dev.marketFactory.enableMarketList()
+			const markets = await dev.marketFactory.getEnabledMarkets()
 			expect(markets.length).to.be.equal(2)
 			expect(markets[0]).to.be.equal(marketAddress)
 			expect(markets[1]).to.be.equal(marketAddress2)


### PR DESCRIPTION
# Description

change func name
enableMarketList->getEnabledMarkets

# Why

Functions without arguments basically start with 'get'
