### PR TITLE
Install truffle-plugin-stdjsonin

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,11 +44,13 @@
 		"eslint-config-xo": "0.39.0",
 		"eslint-config-xo-typescript": "0.49.0",
 		"husky": "7.0.4",
+		"js-base64": "3.7.2",
 		"p-queue": "7.1.0",
 		"prettier": "2.5.1",
 		"prettier-plugin-solidity": "1.0.0-beta.19",
 		"solhint": "3.3.6",
 		"truffle": "5.4.1",
+		"truffle-plugin-stdjsonin": "git+https://github.com/mhrsalehi/truffle-plugin-stdjsonin.git",
 		"truffle-plugin-verify": "0.5.20",
 		"truffle-typings": "1.0.8",
 		"ts-generator": "0.1.1",
@@ -57,8 +59,7 @@
 		"typechain-target-truffle": "1.0.2",
 		"typescript": "4.5.4",
 		"web3": "1.6.1",
-		"web3-utils": "1.6.1",
-		"js-base64": "3.7.2"
+		"web3-utils": "1.6.1"
 	},
 	"dependencies": {
 		"@devprotocol/util-contracts": "3.3.0",

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -75,7 +75,7 @@ module.exports = {
 	db: {
 		enabled: false,
 	},
-	plugins: ['truffle-plugin-verify'],
+	plugins: ['truffle-plugin-verify', 'truffle-plugin-stdjsonin'],
 	api_keys: {
 		etherscan: ETHERSCAN_KEY,
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -15222,6 +15222,12 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
+"truffle-plugin-stdjsonin@git+https://github.com/mhrsalehi/truffle-plugin-stdjsonin.git":
+  version "0.5.14"
+  resolved "git+https://github.com/mhrsalehi/truffle-plugin-stdjsonin.git#80001cc42e7ca922bff30d31b7420485464b1bc7"
+  dependencies:
+    cli-logger "^0.5.40"
+
 truffle-plugin-verify@0.5.20:
   version "0.5.20"
   resolved "https://registry.yarnpkg.com/truffle-plugin-verify/-/truffle-plugin-verify-0.5.20.tgz#3e8e7059bac716319575e584469c1304f21e0ff5"


### PR DESCRIPTION
### Description

<!-- Give a clear description of what modifications you have made -->

Install the new Truffle plugin for creating Standard-JSON-input

### Why is this change needed?

<!-- Please write here about why needs this change -->

In Polyscan, truffle-plugin-verify does not work properly in some cases, and it is necessary to create JSON manually.

#### How to use
```bash
yarn run run stdjsonin CONTRACT_NAME
```

### Related Issues

<!-- If it fixes an issue, please add Closes #issue_no below with its respective issue number -->
<!-- Feel free to add a relevant issue here -->

### Code of Conduct

- [x] By submitting this pull request, I confirm I've read and complied with the [CoC](https://github.com/dev-protocol/protocol/blob/main/CODE_OF_CONDUCT.md) 🖖
