### PR TITLE
Add a new option `bytes32 _payload` for the staking function

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -40,7 +40,9 @@
 				"Truffle": "readonly"
 			},
 			"rules": {
-				"@typescript-eslint/no-unsafe-assignment": "off"
+				"@typescript-eslint/no-unsafe-assignment": "off",
+				"@typescript-eslint/ban-ts-comment": "off",
+				"@typescript-eslint/prefer-ts-expect-error": "off"
 			}
 		}
 	]

--- a/contracts/interface/ILockup.sol
+++ b/contracts/interface/ILockup.sol
@@ -31,6 +31,12 @@ interface ILockup {
 
 	event UpdateCap(uint256 _cap);
 
+	function depositToProperty(
+		address _property,
+		uint256 _amount,
+		bytes32 _data
+	) external returns (uint256);
+
 	function depositToProperty(address _property, uint256 _amount)
 		external
 		returns (uint256);

--- a/contracts/interface/ILockup.sol
+++ b/contracts/interface/ILockup.sol
@@ -34,7 +34,7 @@ interface ILockup {
 	function depositToProperty(
 		address _property,
 		uint256 _amount,
-		bytes32 _data
+		bytes32 _payload
 	) external returns (uint256);
 
 	function depositToProperty(address _property, uint256 _amount)

--- a/contracts/interface/ISTokensManager.sol
+++ b/contracts/interface/ISTokensManager.sol
@@ -86,7 +86,8 @@ interface ISTokensManager {
 		address _owner,
 		address _property,
 		uint256 _amount,
-		uint256 _price
+		uint256 _price,
+		bytes32 _data
 	) external returns (uint256);
 
 	/*
@@ -185,7 +186,8 @@ interface ISTokensManager {
 		uint256 _tokenId,
 		address _owner,
 		StakingPositions memory _positions,
-		Rewards memory _rewards
+		Rewards memory _rewards,
+		bytes32 _data
 	) external view returns (string memory);
 
 	/*

--- a/contracts/interface/ISTokensManager.sol
+++ b/contracts/interface/ISTokensManager.sol
@@ -80,6 +80,7 @@ interface ISTokensManager {
 	 * @param _property The address of the Property as the staking destination
 	 * @param _amount The amount of the new staking position
 	 * @param _price The latest unit price of the cumulative staking reward
+	 * @param _payload additional payload
 	 * @return uint256 The ID of the created new staking position
 	 */
 	function mint(
@@ -87,7 +88,7 @@ interface ISTokensManager {
 		address _property,
 		uint256 _amount,
 		uint256 _price,
-		bytes32 _data
+		bytes32 _payload
 	) external returns (uint256);
 
 	/*
@@ -180,6 +181,7 @@ interface ISTokensManager {
 	 * @param _owner owner address
 	 * @param _positions staking positions
 	 * @param _rewards rewards
+	 * @param _payload token payload
 	 * @return string simulated token uri
 	 */
 	function tokenURISim(
@@ -187,7 +189,7 @@ interface ISTokensManager {
 		address _owner,
 		StakingPositions memory _positions,
 		Rewards memory _rewards,
-		bytes32 _data
+		bytes32 _payload
 	) external view returns (string memory);
 
 	/*
@@ -196,6 +198,13 @@ interface ISTokensManager {
 	 * @return address descriptor address
 	 */
 	function descriptorOf(address _property) external view returns (address);
+
+	/*
+	 * @dev get the payload
+	 * @param _tokenId token id
+	 * @return bytes32 stored payload
+	 */
+	function payloadOf(uint256 _tokenId) external view returns (bytes32);
 
 	/*
 	 * @dev get current token id

--- a/contracts/interface/ITokenURIDescriptor.sol
+++ b/contracts/interface/ITokenURIDescriptor.sol
@@ -17,6 +17,22 @@ interface ITokenURIDescriptor {
 		uint256 _tokenId,
 		address _owner,
 		ISTokensManager.StakingPositions memory _positions,
-		ISTokensManager.Rewards memory _rewards
+		ISTokensManager.Rewards memory _rewards,
+		bytes32 _data
 	) external view returns (string memory);
+
+	/*
+	 * @dev hooks and run a side-effect before minted
+	 * @param _tokenId token id
+	 * @param _owner owner address
+	 * @param _positions staking position
+	 * @param _data user-passed bytes
+	 * @return bool success or failure
+	 */
+	function hooksBeforeMinted(
+		uint256 _tokenId,
+		address _owner,
+		ISTokensManager.StakingPositions memory _positions,
+		bytes32 _data
+	) external returns (bool);
 }

--- a/contracts/interface/ITokenURIDescriptor.sol
+++ b/contracts/interface/ITokenURIDescriptor.sol
@@ -11,6 +11,7 @@ interface ITokenURIDescriptor {
 	 * @param _owner owner address
 	 * @param _positions staking position
 	 * @param _rewards rewards
+	 * @param _payload token payload
 	 * @return string image information
 	 */
 	function image(
@@ -18,7 +19,7 @@ interface ITokenURIDescriptor {
 		address _owner,
 		ISTokensManager.StakingPositions memory _positions,
 		ISTokensManager.Rewards memory _rewards,
-		bytes32 _data
+		bytes32 _payload
 	) external view returns (string memory);
 
 	/*
@@ -26,13 +27,13 @@ interface ITokenURIDescriptor {
 	 * @param _tokenId token id
 	 * @param _owner owner address
 	 * @param _positions staking position
-	 * @param _data user-passed bytes
+	 * @param _payload token payload
 	 * @return bool success or failure
 	 */
-	function hooksBeforeMinted(
+	function onBeforeMint(
 		uint256 _tokenId,
 		address _owner,
 		ISTokensManager.StakingPositions memory _positions,
-		bytes32 _data
+		bytes32 _payload
 	) external returns (bool);
 }

--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -116,21 +116,21 @@ contract Lockup is ILockup, InitializableUsingRegistry {
 	 * @dev deposit dev token to dev protocol and generate s-token
 	 * @param _property target property address
 	 * @param _amount staking value
-	 * @param _data additional bytes for s-token
+	 * @param _payload additional bytes for s-token
 	 * @return tokenId The ID of the created new staking position
 	 */
 	function depositToProperty(
 		address _property,
 		uint256 _amount,
-		bytes32 _data
+		bytes32 _payload
 	) external override returns (uint256) {
-		return _implDepositToProperty(_property, _amount, _data);
+		return _implDepositToProperty(_property, _amount, _payload);
 	}
 
 	function _implDepositToProperty(
 		address _property,
 		uint256 _amount,
-		bytes32 _data
+		bytes32 _payload
 	) private onlyAuthenticatedProperty(_property) returns (uint256) {
 		/**
 		 * Gets the latest cumulative sum of the interest price.
@@ -175,7 +175,7 @@ contract Lockup is ILockup, InitializableUsingRegistry {
 			_property,
 			_amount,
 			interest,
-			_data
+			_payload
 		);
 		emit Lockedup(msg.sender, _property, _amount, tokenId);
 

--- a/contracts/src/lockup/Lockup.sol
+++ b/contracts/src/lockup/Lockup.sol
@@ -107,13 +107,31 @@ contract Lockup is ILockup, InitializableUsingRegistry {
 	function depositToProperty(address _property, uint256 _amount)
 		external
 		override
-		onlyAuthenticatedProperty(_property)
 		returns (uint256)
 	{
-		/**
-		 * Validates _amount is not 0.
-		 */
-		require(_amount != 0, "illegal deposit amount");
+		return _implDepositToProperty(_property, _amount, "");
+	}
+
+	/**
+	 * @dev deposit dev token to dev protocol and generate s-token
+	 * @param _property target property address
+	 * @param _amount staking value
+	 * @param _data additional bytes for s-token
+	 * @return tokenId The ID of the created new staking position
+	 */
+	function depositToProperty(
+		address _property,
+		uint256 _amount,
+		bytes32 _data
+	) external override returns (uint256) {
+		return _implDepositToProperty(_property, _amount, _data);
+	}
+
+	function _implDepositToProperty(
+		address _property,
+		uint256 _amount,
+		bytes32 _data
+	) private onlyAuthenticatedProperty(_property) returns (uint256) {
 		/**
 		 * Gets the latest cumulative sum of the interest price.
 		 */
@@ -156,7 +174,8 @@ contract Lockup is ILockup, InitializableUsingRegistry {
 			msg.sender,
 			_property,
 			_amount,
-			interest
+			interest,
+			_data
 		);
 		emit Lockedup(msg.sender, _property, _amount, tokenId);
 

--- a/contracts/test/stoken/TokenURIDescriptorTest.sol
+++ b/contracts/test/stoken/TokenURIDescriptorTest.sol
@@ -4,12 +4,34 @@ pragma solidity =0.8.9;
 import "../../interface/ITokenURIDescriptor.sol";
 
 contract TokenURIDescriptorTest is ITokenURIDescriptor {
+	mapping(uint256 => bytes32) public _dataOf;
+	bool public shouldBe = true;
+
 	function image(
 		uint256,
 		address,
 		ISTokensManager.StakingPositions memory,
-		ISTokensManager.Rewards memory
+		ISTokensManager.Rewards memory,
+		bytes32
 	) external pure override returns (string memory) {
 		return "dummy-string";
+	}
+
+	function hooksBeforeMinted(
+		uint256 _tokenId,
+		address,
+		ISTokensManager.StakingPositions memory,
+		bytes32 _data
+	) external returns (bool) {
+		_dataOf[_tokenId] = _data;
+		return shouldBe;
+	}
+
+	function dataOf(uint256 _tokenId) external view returns (bytes32) {
+		return _dataOf[_tokenId];
+	}
+
+	function __shouldBe(bool _bool) public {
+		shouldBe = _bool;
 	}
 }

--- a/contracts/test/stoken/TokenURIDescriptorTest.sol
+++ b/contracts/test/stoken/TokenURIDescriptorTest.sol
@@ -17,13 +17,13 @@ contract TokenURIDescriptorTest is ITokenURIDescriptor {
 		return "dummy-string";
 	}
 
-	function hooksBeforeMinted(
+	function onBeforeMint(
 		uint256 _tokenId,
 		address,
 		ISTokensManager.StakingPositions memory,
-		bytes32 _data
+		bytes32 _payload
 	) external returns (bool) {
-		_dataOf[_tokenId] = _data;
+		_dataOf[_tokenId] = _payload;
 		return shouldBe;
 	}
 

--- a/migrations/update/1_update-lockup.ts
+++ b/migrations/update/1_update-lockup.ts
@@ -1,0 +1,24 @@
+const handler = async function (deployer, network) {
+	if (network === 'test') {
+		return
+	}
+
+	const adminAddress = process.env.ADMIN!
+	const proxyAddress = process.env.LOCKUP_PROXY!
+	console.log(`admin address:${adminAddress}`)
+	console.log(`lockup proxy address:${proxyAddress}`)
+
+	const logic = artifacts.require('Lockup')
+	await deployer.deploy(logic)
+	const logicInstance = await logic.deployed()
+	console.log(`logic address:${logicInstance.address}`)
+
+	const adminInstance = await artifacts.require('DevAdmin').at(adminAddress)
+	await adminInstance.upgrade(proxyAddress, logicInstance.address)
+
+	const implAddress = await adminInstance.getProxyImplementation(proxyAddress)
+
+	console.log(`impl address:${implAddress}`)
+} as Truffle.Migration
+
+export = handler

--- a/test/lockup/lockup-s-token.ts
+++ b/test/lockup/lockup-s-token.ts
@@ -59,11 +59,13 @@ contract('LockupTest', ([deployer, , user2, user3]) => {
 				const owner = await dev.sTokensManager.ownerOf(1)
 				expect(owner).to.be.equal(deployer)
 				const position = await dev.sTokensManager.positions(1)
+				const payload = await dev.sTokensManager.payloadOf(1)
 				expect(position.property).to.be.equal(property.address)
 				expect(toBigNumber(position.amount).toNumber()).to.be.equal(100)
 				expect(toBigNumber(position.price).toNumber()).to.be.equal(0)
 				expect(toBigNumber(position.cumulativeReward).toNumber()).to.be.equal(0)
 				expect(toBigNumber(position.pendingReward).toNumber()).to.be.equal(0)
+				expect(payload).to.be.equal(web3.utils.keccak256('ADDITIONAL_BYTES'))
 			})
 			it('0 dev staking', async () => {
 				await dev.lockup.depositToProperty(property.address, 0)

--- a/test/lockup/lockup-s-token.ts
+++ b/test/lockup/lockup-s-token.ts
@@ -48,6 +48,31 @@ contract('LockupTest', ([deployer, , user2, user3]) => {
 				expect(toBigNumber(position.cumulativeReward).toNumber()).to.be.equal(0)
 				expect(toBigNumber(position.pendingReward).toNumber()).to.be.equal(0)
 			})
+			it('passe the 3rd option', async () => {
+				await dev.dev.approve(dev.lockup.address, 100)
+				// @ts-ignore
+				await dev.lockup.depositToProperty(
+					property.address,
+					100,
+					web3.utils.keccak256('ADDITIONAL_BYTES')
+				)
+				const owner = await dev.sTokensManager.ownerOf(1)
+				expect(owner).to.be.equal(deployer)
+				const position = await dev.sTokensManager.positions(1)
+				expect(position.property).to.be.equal(property.address)
+				expect(toBigNumber(position.amount).toNumber()).to.be.equal(100)
+				expect(toBigNumber(position.price).toNumber()).to.be.equal(0)
+				expect(toBigNumber(position.cumulativeReward).toNumber()).to.be.equal(0)
+				expect(toBigNumber(position.pendingReward).toNumber()).to.be.equal(0)
+			})
+			it('0 dev staking', async () => {
+				await dev.lockup.depositToProperty(property.address, 0)
+				const owner = await dev.sTokensManager.ownerOf(1)
+				expect(owner).to.be.equal(deployer)
+				const position = await dev.sTokensManager.positions(1)
+				expect(position.property).to.be.equal(property.address)
+				expect(toBigNumber(position.amount).toNumber()).to.be.equal(0)
+			})
 			it('get 2 nft token.', async () => {
 				await dev.dev.approve(dev.lockup.address, 100)
 				await dev.lockup.depositToProperty(property.address, 100)
@@ -164,12 +189,6 @@ contract('LockupTest', ([deployer, , user2, user3]) => {
 					.depositToProperty(propertyAddress, 100)
 					.catch(err)
 				validateErrorMessage(res, 'unable to stake to unauthenticated property')
-			})
-			it('0 dev staking is not possible.', async () => {
-				const res = await dev.lockup
-					.depositToProperty(property.address, 0)
-					.catch(err)
-				validateErrorMessage(res, 'illegal deposit amount')
 			})
 			it('user is not holding dev.', async () => {
 				const res = await dev.lockup

--- a/test/s-token/s-token-manager.ts
+++ b/test/s-token/s-token-manager.ts
@@ -257,7 +257,7 @@ contract('STokensManager', ([deployer, user]) => {
 		describe('fail', () => {
 			it('If the owner runs it, an error will occur.', async () => {
 				const res = await dev.sTokensManager
-					.mint(deployer, property.address, 100, 10, '')
+					.mint(deployer, property.address, 100, 10, '0x')
 					.catch((err: Error) => err)
 				validateErrorMessage(res, 'illegal access')
 			})
@@ -757,7 +757,7 @@ contract('STokensManager', ([deployer, user]) => {
 				DEFAULT_ADDRESS,
 				positions,
 				rewards,
-				''
+				'0x'
 			)
 			checkTokenUri(
 				tmp,
@@ -777,7 +777,7 @@ contract('STokensManager', ([deployer, user]) => {
 				DEFAULT_ADDRESS,
 				positions,
 				rewards,
-				''
+				'0x'
 			)
 			checkTokenUri(
 				tokenUri,
@@ -799,7 +799,7 @@ contract('STokensManager', ([deployer, user]) => {
 				DEFAULT_ADDRESS,
 				positions,
 				rewards,
-				''
+				'0x'
 			)
 			checkTokenUri(
 				tmp,

--- a/test/s-token/s-token-manager.ts
+++ b/test/s-token/s-token-manager.ts
@@ -676,7 +676,7 @@ contract('STokensManager', ([deployer, user]) => {
 				const tmp = await dev.sTokensManager.descriptorOf(property.address)
 				expect(tmp).to.equal(descriptor.address)
 			})
-			it('stores the passed bytes', async () => {
+			it('stores the passed payload', async () => {
 				await dev.sTokensManager.setTokenURIDescriptor(
 					property.address,
 					descriptor.address,
@@ -699,7 +699,7 @@ contract('STokensManager', ([deployer, user]) => {
 					.catch((err: Error) => err)
 				validateErrorMessage(res, 'illegal access')
 			})
-			it('revert on hooksBeforeMinted', async () => {
+			it('revert on onBeforeMint', async () => {
 				await dev.sTokensManager.setTokenURIDescriptor(
 					property.address,
 					descriptor.address,
@@ -714,7 +714,7 @@ contract('STokensManager', ([deployer, user]) => {
 						web3.utils.keccak256('ADDITIONAL_BYTES')
 					)
 					.catch((err: Error) => err)
-				validateErrorMessage(res, 'failed to call hooksBeforeMinted')
+				validateErrorMessage(res, 'failed to call onBeforeMint')
 			})
 		})
 	})

--- a/test/s-token/s-token-manager.ts
+++ b/test/s-token/s-token-manager.ts
@@ -257,7 +257,7 @@ contract('STokensManager', ([deployer, user]) => {
 		describe('fail', () => {
 			it('If the owner runs it, an error will occur.', async () => {
 				const res = await dev.sTokensManager
-					.mint(deployer, property.address, 100, 10)
+					.mint(deployer, property.address, 100, 10, '')
 					.catch((err: Error) => err)
 				validateErrorMessage(res, 'illegal access')
 			})
@@ -676,6 +676,21 @@ contract('STokensManager', ([deployer, user]) => {
 				const tmp = await dev.sTokensManager.descriptorOf(property.address)
 				expect(tmp).to.equal(descriptor.address)
 			})
+			it('stores the passed bytes', async () => {
+				await dev.sTokensManager.setTokenURIDescriptor(
+					property.address,
+					descriptor.address,
+					{ from: user }
+				)
+				// @ts-ignore
+				await dev.lockup.depositToProperty(
+					property.address,
+					'10000',
+					web3.utils.keccak256('ADDITIONAL_BYTES')
+				)
+				const key = await descriptor.dataOf(1)
+				expect(key).to.equal(web3.utils.keccak256('ADDITIONAL_BYTES'))
+			})
 		})
 		describe('fail', () => {
 			it('illegal property', async () => {
@@ -683,6 +698,23 @@ contract('STokensManager', ([deployer, user]) => {
 					.setTokenURIDescriptor(property.address, descriptor.address)
 					.catch((err: Error) => err)
 				validateErrorMessage(res, 'illegal access')
+			})
+			it('revert on hooksBeforeMinted', async () => {
+				await dev.sTokensManager.setTokenURIDescriptor(
+					property.address,
+					descriptor.address,
+					{ from: user }
+				)
+				await descriptor.__shouldBe(false)
+				// @ts-ignore
+				const res = await dev.lockup
+					.depositToProperty(
+						property.address,
+						'10000',
+						web3.utils.keccak256('ADDITIONAL_BYTES')
+					)
+					.catch((err: Error) => err)
+				validateErrorMessage(res, 'failed to call hooksBeforeMinted')
 			})
 		})
 	})
@@ -724,7 +756,8 @@ contract('STokensManager', ([deployer, user]) => {
 				1,
 				DEFAULT_ADDRESS,
 				positions,
-				rewards
+				rewards,
+				''
 			)
 			checkTokenUri(
 				tmp,
@@ -743,7 +776,8 @@ contract('STokensManager', ([deployer, user]) => {
 				1,
 				DEFAULT_ADDRESS,
 				positions,
-				rewards
+				rewards,
+				''
 			)
 			checkTokenUri(
 				tokenUri,
@@ -764,7 +798,8 @@ contract('STokensManager', ([deployer, user]) => {
 				1,
 				DEFAULT_ADDRESS,
 				positions,
-				rewards
+				rewards,
+				''
 			)
 			checkTokenUri(
 				tmp,


### PR DESCRIPTION
### Description

<!-- Give a clear description of what modifications you have made -->

- Add the new (overloaded) interface `function depositToProperty(address _property, uint256 _amount, bytes32 _data)`
- And add required changes for that

### Why is this change needed?

<!-- Please write here about why needs this change -->

For the generation of dynamic images on a Dynamic sTokens, more flexible customization is realized by receiving additional data at the time of mint.

### Related Issues

<!-- If it fixes an issue, please add Closes #issue_no below with its respective issue number -->
<!-- Feel free to add a relevant issue here -->

### Todo

- [x] Arbitrum Rinkeby: Deploy Lockup
- [x] Arbitrum Rinkeby: Deploy STokensManager
- [x] Arbitrum One: Deploy Lockup
- [x] Arbitrum One: Deploy STokensManager
- [x] Polygon Mumbai: Deploy Lockup
- [x] Polygon Mumbai: Deploy STokensManager
- [x] Polygon: Deploy Lockup
- [x] Polygon: Deploy STokensManager

### Code of Conduct

- [x] By submitting this pull request, I confirm I've read and complied with the [CoC](https://github.com/dev-protocol/protocol/blob/main/CODE_OF_CONDUCT.md) 🖖
