### PR TITLE
Supports optional `animation_url`

### DIFF
--- a/contracts/interface/ITokenURIDescriptor.sol
+++ b/contracts/interface/ITokenURIDescriptor.sol
@@ -23,6 +23,23 @@ interface ITokenURIDescriptor {
 	) external view returns (string memory);
 
 	/*
+	 * @dev get animation_url from custom descriptor
+	 * @param _tokenId token id
+	 * @param _owner owner address
+	 * @param _positions staking position
+	 * @param _rewards rewards
+	 * @param _payload token payload
+	 * @return string image information
+	 */
+	function animationUrl(
+		uint256 _tokenId,
+		address _owner,
+		ISTokensManager.StakingPositions memory _positions,
+		ISTokensManager.Rewards memory _rewards,
+		bytes32 _payload
+	) external view returns (string memory);
+
+	/*
 	 * @dev get name from custom descriptor
 	 * @param _tokenId token id
 	 * @param _owner owner address

--- a/contracts/src/s-token/STokensDescriptor.sol
+++ b/contracts/src/s-token/STokensDescriptor.sol
@@ -170,14 +170,30 @@ contract STokensDescriptor {
 	}
 
 	function getTokenURI(
-		address _property,
-		uint256 _amount,
-		uint256 _cumulativeReward,
-		string memory _tokenUriImage,
-		string memory _tokenUriName,
-		string memory _tokenUriDescription,
-		bytes32 _payload
+		bytes memory _props
 	) internal pure returns (string memory) {
+		(
+			address _property,
+			uint256 _amount,
+			uint256 _cumulativeReward,
+			string memory _tokenUriImage,
+			string memory _tokenUriName,
+			string memory _tokenUriDescription,
+			string memory _tokenUriAnimationUrl,
+			bytes32 _payload
+		) = abi.decode(
+				_props,
+				(
+					address,
+					uint256,
+					uint256,
+					string,
+					string,
+					string,
+					string,
+					bytes32
+				)
+			);
 		string memory amount = _amount.decimalString(18);
 		string memory name = bytes(_tokenUriName).length == 0
 			? string(
@@ -244,6 +260,15 @@ contract STokensDescriptor {
 				)
 			)
 			: _tokenUriImage;
+		string memory animationUrl = bytes(_tokenUriAnimationUrl).length == 0
+			? string("")
+			: string(
+				abi.encodePacked(
+					// solhint-disable-next-line quotes
+					'", "animation_url":"',
+					_tokenUriAnimationUrl
+				)
+			);
 		return
 			string(
 				abi.encodePacked(
@@ -259,6 +284,7 @@ contract STokensDescriptor {
 							// solhint-disable-next-line quotes
 							'", "image": "',
 							image,
+							animationUrl,
 							// solhint-disable-next-line quotes
 							'", "attributes":',
 							attributes,

--- a/contracts/src/s-token/STokensManager.sol
+++ b/contracts/src/s-token/STokensManager.sol
@@ -305,6 +305,7 @@ contract STokensManager is
 		string memory _tokenUriImage = tokenUriImage[_tokenId];
 		string memory _tokenUriName;
 		string memory _tokenUriDescription;
+		string memory _tokenUriAnimationUrl;
 		address descriptor = descriptorOfPropertyByPayload[_positions.property][
 			_payload
 		] == address(0)
@@ -352,16 +353,32 @@ contract STokensManager is
 			} catch {
 				_tokenUriDescription = "";
 			}
+			try
+				ITokenURIDescriptor(descriptor).animationUrl(
+					_tokenId,
+					_owner,
+					_positions,
+					_rewardsArg,
+					_payload
+				)
+			returns (string memory _animation_url) {
+				_tokenUriAnimationUrl = _animation_url;
+			} catch {
+				_tokenUriAnimationUrl = "";
+			}
 		}
 		return
 			getTokenURI(
-				_positions.property,
-				_positions.amount,
-				_positions.cumulativeReward,
-				_tokenUriImage,
-				_tokenUriName,
-				_tokenUriDescription,
-				_payload
+				abi.encode(
+					_positions.property,
+					_positions.amount,
+					_positions.cumulativeReward,
+					_tokenUriImage,
+					_tokenUriName,
+					_tokenUriDescription,
+					_tokenUriAnimationUrl,
+					_payload
+				)
 			);
 	}
 

--- a/contracts/test/stoken/TokenURIDescriptorCopyTest.sol
+++ b/contracts/test/stoken/TokenURIDescriptorCopyTest.sol
@@ -9,7 +9,6 @@ contract TokenURIDescriptorCopyTest is ITokenURIDescriptor {
 	string public newName = "";
 	string public newDescription = "";
 	string public newImage = "dummy-string";
-	string public newAnimationUrl = "dummy-string";
 
 	function image(
 		uint256,
@@ -27,8 +26,8 @@ contract TokenURIDescriptorCopyTest is ITokenURIDescriptor {
 		ISTokensManager.StakingPositions memory,
 		ISTokensManager.Rewards memory,
 		bytes32
-	) external view override returns (string memory) {
-		return newAnimationUrl;
+	) external pure override returns (string memory) {
+		return "";
 	}
 
 	function onBeforeMint(

--- a/contracts/test/stoken/TokenURIDescriptorCopyTest.sol
+++ b/contracts/test/stoken/TokenURIDescriptorCopyTest.sol
@@ -9,6 +9,7 @@ contract TokenURIDescriptorCopyTest is ITokenURIDescriptor {
 	string public newName = "";
 	string public newDescription = "";
 	string public newImage = "dummy-string";
+	string public newAnimationUrl = "dummy-string";
 
 	function image(
 		uint256,
@@ -18,6 +19,16 @@ contract TokenURIDescriptorCopyTest is ITokenURIDescriptor {
 		bytes32
 	) external view override returns (string memory) {
 		return newImage;
+	}
+
+	function animationUrl(
+		uint256,
+		address,
+		ISTokensManager.StakingPositions memory,
+		ISTokensManager.Rewards memory,
+		bytes32
+	) external view override returns (string memory) {
+		return newAnimationUrl;
 	}
 
 	function onBeforeMint(

--- a/contracts/test/stoken/TokenURIDescriptorTest.sol
+++ b/contracts/test/stoken/TokenURIDescriptorTest.sol
@@ -9,6 +9,7 @@ contract TokenURIDescriptorTest is ITokenURIDescriptor {
 	string public newName = "";
 	string public newDescription = "";
 	string public newImage = "dummy-string";
+	string public newAnimationUrl = "dummy-string";
 
 	function image(
 		uint256,
@@ -18,6 +19,16 @@ contract TokenURIDescriptorTest is ITokenURIDescriptor {
 		bytes32
 	) external view override returns (string memory) {
 		return newImage;
+	}
+
+	function animationUrl(
+		uint256,
+		address,
+		ISTokensManager.StakingPositions memory,
+		ISTokensManager.Rewards memory,
+		bytes32
+	) external view returns (string memory) {
+		return newAnimationUrl;
 	}
 
 	function onBeforeMint(

--- a/contracts/test/stoken/TokenURIDescriptorTest.sol
+++ b/contracts/test/stoken/TokenURIDescriptorTest.sol
@@ -9,7 +9,7 @@ contract TokenURIDescriptorTest is ITokenURIDescriptor {
 	string public newName = "";
 	string public newDescription = "";
 	string public newImage = "dummy-string";
-	string public newAnimationUrl = "dummy-string";
+	string public newAnimationUrl = "dummy-animation-string";
 
 	function image(
 		uint256,
@@ -59,6 +59,10 @@ contract TokenURIDescriptorTest is ITokenURIDescriptor {
 
 	function _setImageURI(string memory _imageURI) public {
 		newImage = _imageURI;
+	}
+
+	function _setAnimationUrl(string memory _animationUrl) public {
+		newAnimationUrl = _animationUrl;
 	}
 
 	function name(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2527,7 +2527,7 @@
   version "0.2.0"
   resolved "https://codeload.github.com/trufflesuite/filecoin-signing-tools-js/tar.gz/2786fdb8a2b71bd1c7789c0701da41bb644a098f"
   dependencies:
-    axios "^0.20.0"
+    axios "0.26.1"
     base32-decode "^1.0.0"
     base32-encode "^1.1.1"
     bip32 "^2.0.5"


### PR DESCRIPTION
### Description

<!-- Give a clear description of what modifications you have made -->

sTokens defines the `animation_url` property for the tokenURI if the custom descriptor implements `animationUrl` function.

### Why is this change needed?

<!-- Please write here about why needs this change -->

To support rich media such as video and music with Clubs.

### Related Issues

<!-- If it fixes an issue, please add Closes #issue_no below with its respective issue number -->
<!-- Feel free to add a relevant issue here -->

### Code of Conduct

- [x] By submitting this pull request, I confirm I've read and complied with the [CoC](https://github.com/dev-protocol/protocol/blob/main/CODE_OF_CONDUCT.md) 🖖
